### PR TITLE
Added warning for missing _init method

### DIFF
--- a/src/js/plugin.js
+++ b/src/js/plugin.js
@@ -17,6 +17,11 @@
 }(function($) {
     function Plugin(element, options, defaultOptions) {
         this.options = $.extend(true, {}, defaultOptions, options);
+
+        if (typeof this._init !== 'function') {
+            throw this.name + ' needs an _init method';
+        }
+
         this._init(element);
     }
 


### PR DESCRIPTION
We always expect an _init method in a plugin that extends..err...plugin. Throw an error if _init is not found.

Status: **Ready for merge**
Reviewers: @scalvert @tedtate
